### PR TITLE
Updated the base docs url to point to jbogard instead of headspringlabs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,7 +16,7 @@
 title: "Bulk Writer"
 description: "Bulk Writer is a small library which facilitates building fast, memory-efficient, pull-based ETL processes in C#."
 baseurl: "/bulk-writer" # the subpath of your site, e.g. /blog
-url: "https://headspringlabs.github.io" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://jbogard.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
Hi Jimmy,

The readme points to the docs at https://jbogard.github.io/bulk-writer/, but the links within the docs themselves still point to the old headspringlabs site (e.g., https://headspringlabs.github.io/bulk-writer/gettingstarted.html).

I'm not sure how the docs are generated, but hopefully this config change will result in the correct URLs in the docs.

Thanks,

Jon